### PR TITLE
Enabled game data and C++ 17 support

### DIFF
--- a/ASGEDemo/CTP-DOD-IN-OOD/CMakeLists.txt
+++ b/ASGEDemo/CTP-DOD-IN-OOD/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11.4)
 project(Allman)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 ## project independent scripts ##
 include(cmake/build/flags.cmake)
@@ -18,4 +18,3 @@ endif()
 
 ## enable the game project ##
 add_subdirectory(src)
-

--- a/ASGEDemo/CTP-DOD-IN-OOD/src/CMakeLists.txt
+++ b/ASGEDemo/CTP-DOD-IN-OOD/src/CMakeLists.txt
@@ -71,4 +71,8 @@ if (NOT CMAKE_BUILD_TYPE STREQUAL  "Debug" AND WIN32)
     target_compile_options(${PROJECT_NAME} PRIVATE -mwindows)
 endif()
 
+add_custom_command(
+        TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/data $<TARGET_FILE_DIR:${PROJECT_NAME}>/data)
 

--- a/ASGEDemo/CTP-DOD-IN-OOD/src/game/GameObjects/AllmanSquare.cpp
+++ b/ASGEDemo/CTP-DOD-IN-OOD/src/game/GameObjects/AllmanSquare.cpp
@@ -34,22 +34,15 @@ void AllmanSquare::InitSprite(ASGE::Renderer* renderer)
     _sprite->loadTexture("/data/g.png");    //TODO Fix Sprite here
     _sprite->xPos(_position.Get()._x);
     _sprite->yPos(_position.Get()._y);
-    _sprite->scale(_scale.Get());
+    _sprite->scale(0.1);
     _sprite->colour(_squareCol.Get());
 }
 
 void AllmanSquare::Render(ASGE::Renderer *renderer)
 {
-//    renderer->renderSprite(*_sprite);
+    renderer->renderSprite(*(_sprite.get()));
     const int xPos = static_cast<int>(_position.Get()._x);
     const int yPos = static_cast<int>(_position.Get()._y);
-
-    renderer->renderText(
-            "&",
-            xPos,
-            yPos,
-            _squareCol.Get()
-    );
 }
 
 void AllmanSquare::SetColour(ASGE::Colour col)

--- a/ASGEDemo/CTP-DOD-IN-OOD/src/game/GameObjects/AllmanSquare.h
+++ b/ASGEDemo/CTP-DOD-IN-OOD/src/game/GameObjects/AllmanSquare.h
@@ -9,18 +9,18 @@ class AllmanSquare : public GameObject
 {
 public:
     AllmanSquare() = delete;
-	explicit AllmanSquare(ASGE::Renderer* renderer, MemoryManager* memoryManager);
-	explicit AllmanSquare(ASGE::Renderer* renderer, MemoryManager* memoryManager, const Vector& pos);
+    explicit AllmanSquare(ASGE::Renderer* renderer, MemoryManager* memoryManager);
+    explicit AllmanSquare(ASGE::Renderer* renderer, MemoryManager* memoryManager, const Vector& pos);
     ~AllmanSquare() override = default;
 
     void InitSprite(ASGE::Renderer* renderer) override;
     void Render(ASGE::Renderer *renderer) override;
     void SetColour(ASGE::Colour col);
 
-	Vector GetPosition() const override;
-	void SetPosition(const Vector &newPos) override;
+    Vector GetPosition() const override;
+    void SetPosition(const Vector &newPos) override;
 
-	static constexpr float _posLimit = 30.0f;
+    static constexpr float _posLimit = 30.0f;
     static constexpr float _scaleLimit = 0.5f;
 
     AllmanVariable<Vector>& AllmanPosition() { return _position; }

--- a/ASGEDemo/CTP-DOD-IN-OOD/src/game/GameObjects/Square.cpp
+++ b/ASGEDemo/CTP-DOD-IN-OOD/src/game/GameObjects/Square.cpp
@@ -75,14 +75,14 @@ void Square::UpdateSpriteColour(double totalTime)
 
 void Square::Render(ASGE::Renderer *renderer)
 {
-//    renderer->renderSprite(*_sprite);
+   renderer->renderSprite(*_sprite);
     int xPos = static_cast<int>(_position._x);
     int yPos = static_cast<int>(_position._y);
 
-    renderer->renderText(
-            "&",
-            xPos,
-            yPos,
-            _squareCol
-        );
+//    renderer->renderText(
+//            "&",
+//            xPos,
+//            yPos,
+//            _squareCol
+//        );
 }

--- a/ASGEDemo/CTP-DOD-IN-OOD/src/game/Scenes/NoSystemsScene.cpp
+++ b/ASGEDemo/CTP-DOD-IN-OOD/src/game/Scenes/NoSystemsScene.cpp
@@ -17,7 +17,12 @@ NoSystemsScene::NoSystemsScene(MyASGEGame *gameRef, ASGE::Renderer* renderer, in
     {
         for(int y = -_demoSpanMod; y < yCount + _demoSpanMod; ++y)
         {
-            _squares.emplace_back(std::make_unique<Square>(renderer, Vector(static_cast<float>(x * offset), static_cast<float>(y * offset))) );
+          _squares.emplace_back(
+              std::make_unique<Square>(
+                  renderer,
+                  Vector(static_cast<float>(x * offset),
+                                static_cast<float>(y * offset))))
+              ->InitSprite(renderer);
         }
     }
 }

--- a/ASGEDemo/CTP-DOD-IN-OOD/src/game/Scenes/SystemsScene.h
+++ b/ASGEDemo/CTP-DOD-IN-OOD/src/game/Scenes/SystemsScene.h
@@ -21,7 +21,7 @@ public:
     void KeyHandler(const ASGE::SharedEventData &data) override;
 
 private:
-	void SetJobsForUpdate(double dt);
+    void SetJobsForUpdate(double dt);
     void UpdateSquarePosition(int startInd, int endInd, double dt);
     void UpdateSquareScale(int startInd, int endInd, double dt);
     void UpdateSquareColour(int startInd, int endInd, double totalTime);
@@ -30,7 +30,7 @@ private:
 
 
     bool _jobSystemActive = true;
-	std::unique_ptr<JobSystem> _jobSystem;
+    std::unique_ptr<JobSystem> _jobSystem;
     std::unique_ptr<MemoryManager> _memoryManager;
     std::vector<AllmanSquare> _squares;
 
@@ -47,5 +47,5 @@ private:
             ASGE::Colour(0.972f, 0.039f, 1.0f)          //V
     };
 
-	const int _demoSpanMod;
+    const int _demoSpanMod;
 };


### PR DESCRIPTION
- Data folder is now copied at end of build
- C++ 17 enabled to allow use of emplace_back references
- Sprites initialised when added to squares vectors
- Scaled down the sprite on systems scene to make it more visible